### PR TITLE
Update jsk_spot_watch_dog 

### DIFF
--- a/jsk_spot_watch_dog/CMakeLists.txt
+++ b/jsk_spot_watch_dog/CMakeLists.txt
@@ -18,7 +18,7 @@ include_directories(
 ## Install ##
 #############
 
-catkin_install_python(PROGRAMS scripts/watch_dog.py
+catkin_install_python(PROGRAMS scripts/watch_dog_smach.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 

--- a/jsk_spot_watch_dog/launch/watch_dog_roseus_smach.launch
+++ b/jsk_spot_watch_dog/launch/watch_dog_roseus_smach.launch
@@ -16,8 +16,8 @@
   <node pkg="sound_play" type="soundplay_node.py" name="sound_play" />
 
   # watch dog smach
-  <node pkg="roseus" type="roseus" name="spot_watchdog" output="screen"
-        args="$(find jsk_spot_watch_dog)/scripts/watch-dog.l" >
+  <node pkg="jsk_spot_watch_dog" type="watch-dog.l" name="spot_watchdog" output="screen"
+        args="&quot;(progn (watchdog-init nil) (exec-state-machine (watchdog-sm)))&quot;" >
     <remap from="~input" to="$(arg input_image)" />
     <remap from="~panorama_image" to="$(arg panorama_image)" />
     <remap from="~human" to="$(arg human_detection_result)" />

--- a/jsk_spot_watch_dog/package.xml
+++ b/jsk_spot_watch_dog/package.xml
@@ -14,6 +14,8 @@
   <depend>rospy</depend>
   <depend>smach</depend>
   <depend>smach_ros</depend>
+  <depend>jsk_spot_startup</depend>
+  <depend>spoteus</depend>
   
   <export>
 

--- a/jsk_spot_watch_dog/scripts/watch-dog.l
+++ b/jsk_spot_watch_dog/scripts/watch-dog.l
@@ -111,7 +111,7 @@
       (ros::spin-once)
       (send *ri* :spin-once)
       (setq ret (func-day-basic userdata-alist))
-      (if ret (return-from func-watch ret))
+      (if ret (return-from func-rest ret))
       (when (> (/ (send (ros::time- (ros::time-now) (send *ri* :get-val 'stand-start-time)) :to-sec) 60)
              (send *ri* :get-val 'rest-time-per-hour))
         (ros::ros-info  "finish rest")

--- a/jsk_spot_watch_dog/scripts/watch-dog.l
+++ b/jsk_spot_watch_dog/scripts/watch-dog.l
@@ -224,8 +224,8 @@
     sm))
 
 ;; create robot interface
-(watchdog-init nil)
+;;(watchdog-init nil)
 
 ;; state machine
-(exec-state-machine (watchdog-sm))
+;;(exec-state-machine (watchdog-sm))
 


### PR DESCRIPTION
I wanted to run another program that inherited from watch-dog-interface, so I rewrote watch-dog.l so that the program would not be executed just by loading it, but would be executed when the launch file was started.
And I fixed minor bugs.
Cc @708yamaguchi